### PR TITLE
Remove outdated Lichess Puzzles entry from puzzle databases

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -91,13 +91,6 @@ const DATABASES: DownloadableDatabase[] = [
 
 const PUZZLE_DATABASES: DownloadablePuzzleDatabase[] = [
   {
-    title: "Lichess Puzzles",
-    description: "A collection of all puzzles from Lichess.org",
-    puzzleCount: 3080529,
-    storageSize: BigInt(339046400),
-    downloadLink: "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/puzzles.db3",
-  },
-  {
     title: "Lichess Puzzles 2025",
     description: "Latest puzzles from Lichess.org organized by themes in database format",
     puzzleCount: 5600086,


### PR DESCRIPTION
# Pull Request

## Description
Removes the unavailable default `Lichess Puzzles` download entry that points to `puzzles.db3` and currently returns `401 Unauthorized`.

The working `Lichess Puzzles 2025` download option remains available, so users still have a default puzzle database they can download.

Related issue: #6

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows, local checkout.

Ran:

```sh
corepack pnpm lint
```

Result: TypeScript check completed successfully. Biome reported existing warnings in unrelated files, but no error was introduced by this change.

## Screenshots / Additional Context
Verified the removed URL returns `401 Unauthorized`:

```sh
curl.exe -I -L "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/puzzles.db3"
```

Verified the remaining puzzle database URL returns `200 OK`.

## Checklist
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness