### PR TITLE
fix: prune broken downloadable content

### DIFF
--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -44,41 +44,6 @@ export type DownloadablePuzzleDatabase = {
 
 const DATABASES: DownloadableDatabase[] = [
   {
-    title: "Lumbra's Gigabase",
-    game_count: 9570564,
-    player_count: 526520,
-    storage_size: BigInt(2789040128),
-    downloadLink: "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/LumbrasGigaBase2025-06.db3",
-  },
-  {
-    title: "Caissabase 2024",
-    game_count: 5404926,
-    player_count: 321095,
-    storage_size: BigInt(1318744064),
-    downloadLink: "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/caissabase_2024.db3",
-  },
-  {
-    title: "Ajedrez Data - Correspondence",
-    game_count: 1524027,
-    player_count: 40547,
-    storage_size: BigInt(328458240),
-    downloadLink: "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/AJ-COR.db3",
-  },
-  {
-    title: "Ajedrez Data - OTB",
-    game_count: 4279012,
-    player_count: 144015,
-    storage_size: BigInt(993509376),
-    downloadLink: "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/AJ-OTB.db3",
-  },
-  {
-    title: "MillionBase",
-    game_count: 3451068,
-    player_count: 284403,
-    storage_size: BigInt(779833344),
-    downloadLink: "https://pub-561e4f3376ea4e4eb2ffd01a876ba46e.r2.dev/mb-3.db3",
-  },
-  {
     title: "Position Cache",
     game_count: 0,
     player_count: 0,

--- a/src/utils/engines.ts
+++ b/src/utils/engines.ts
@@ -598,8 +598,8 @@ const ENGINES = [
     bmi2: true,
     image: "https://upload.wikimedia.org/wikipedia/commons/6/6f/Chess_icon.svg",
     installMethod: "download" as const,
-    downloadLink: "https://github.com/gab8192/Obsidian/releases/download/v16.0/Obsidian_16.0_avx2.exe",
-    path: "obsidian/Obsidian_16.0_avx2.exe",
+    downloadLink: "https://github.com/gab8192/Obsidian/releases/download/v16.0/Obsidian160-avx2-pext.exe",
+    path: "obsidian/Obsidian160-avx2-pext.exe",
     elo: 0,
   },
 


### PR DESCRIPTION
# Pull Request

## Description
Removes downloadable database entries whose R2 URLs currently return `401 Unauthorized`.

Also fixes the Obsidian 16 engine download URL, which pointed to a non-existent release asset and returned `404 Not Found`.

The working `Lichess Puzzles 2025` and `Position Cache` download options remain available.

Related issue: #6

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows, local checkout.

Ran:

```sh
corepack pnpm lint
```

Result: TypeScript check completed successfully. Biome reported existing warnings in unrelated files.

## Screenshots / Additional Context
Verified removed R2 database URLs return `401 Unauthorized`.

Verified these remaining/fixed URLs return `200 OK`:
- `Lichess Puzzles 2025`
- `Position Cache`
- `Obsidian160-avx2-pext.exe`

## Checklist
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness