### PR TITLE
fix: update puzzle and database types to support optional download links

### DIFF
--- a/src/features/boards/components/puzzles/AddPuzzle.tsx
+++ b/src/features/boards/components/puzzles/AddPuzzle.tsx
@@ -228,7 +228,7 @@ function PuzzleDbCard({
   closeModal,
 }: {
   setPuzzleDbs: Dispatch<SetStateAction<PuzzleDatabaseInfo[]>>;
-  puzzleDb: PuzzleDatabaseInfo & { downloadLink: string };
+  puzzleDb: PuzzleDatabaseInfo & { downloadLink?: string; manualDownloadLink?: string };
   databaseId: number;
   initInstalled: boolean;
   closeModal: () => void;
@@ -362,22 +362,30 @@ function PuzzleDbCard({
               <Text size="xs">{t("units.count", { count: puzzleDb.puzzleCount })}</Text>
             </Stack>
           </Group>
-          <ProgressButton
-            id={`puzzle_db_${databaseId}`}
-            progressEvent={events.downloadProgress}
-            initInstalled={initInstalled}
-            labels={{
-              completed: t("common.installed"),
-              action: t("common.install"),
-              inProgress: t("common.downloading"),
-              finalizing: t("common.extracting"),
-            }}
-            onClick={() =>
-              downloadDatabase(databaseId, puzzleDb.downloadLink || "", puzzleDb.title, puzzleDb.description)
-            }
-            inProgress={inProgress}
-            setInProgress={setInProgress}
-          />
+          {puzzleDb.downloadLink ? (
+            <ProgressButton
+              id={`puzzle_db_${databaseId}`}
+              progressEvent={events.downloadProgress}
+              initInstalled={initInstalled}
+              labels={{
+                completed: t("common.installed"),
+                action: t("common.install"),
+                inProgress: t("common.downloading"),
+                finalizing: t("common.extracting"),
+              }}
+              onClick={() =>
+                downloadDatabase(databaseId, puzzleDb.downloadLink ?? "", puzzleDb.title, puzzleDb.description)
+              }
+              inProgress={inProgress}
+              setInProgress={setInProgress}
+            />
+          ) : (
+            puzzleDb.manualDownloadLink && (
+              <Button component="a" href={puzzleDb.manualDownloadLink} target="_blank" rel="noreferrer" fullWidth>
+                {t("common.download")}
+              </Button>
+            )
+          )}
         </Box>
       </Group>
     </Paper>

--- a/src/features/databases/components/modals/AddDatabase.tsx
+++ b/src/features/databases/components/modals/AddDatabase.tsx
@@ -55,7 +55,7 @@ interface AddDatabaseProps {
 
 interface DatabaseCardProps {
   setDatabases: () => void;
-  database: SuccessDatabaseInfo;
+  database: SuccessDatabaseInfo & { downloadLink?: string; manualDownloadLink?: string };
   databaseId: number;
   initInstalled: boolean;
   closeModal: () => void;
@@ -63,7 +63,7 @@ interface DatabaseCardProps {
 
 interface PuzzleDbCardProps {
   setPuzzleDbs: Dispatch<SetStateAction<PuzzleDatabaseInfo[]>>;
-  puzzleDb: PuzzleDatabaseInfo & { downloadLink: string };
+  puzzleDb: PuzzleDatabaseInfo & { downloadLink?: string; manualDownloadLink?: string };
   databaseId: number;
   initInstalled: boolean;
 }
@@ -463,20 +463,28 @@ function DatabaseCard({ setDatabases, database, databaseId, initInstalled, close
         </Stack>
       </Group>
 
-      <ProgressButton
-        id={database.title === "Position Cache" ? "db_position_cache" : `db_${databaseId}`}
-        progressEvent={events.downloadProgress}
-        initInstalled={isInstalled}
-        labels={{
-          completed: t("common.installed"),
-          action: t("common.install"),
-          inProgress: t("common.downloading"),
-          finalizing: t("common.extracting"),
-        }}
-        onClick={handleDownload}
-        inProgress={inProgress}
-        setInProgress={setInProgress}
-      />
+      {database.downloadLink ? (
+        <ProgressButton
+          id={database.title === "Position Cache" ? "db_position_cache" : `db_${databaseId}`}
+          progressEvent={events.downloadProgress}
+          initInstalled={isInstalled}
+          labels={{
+            completed: t("common.installed"),
+            action: t("common.install"),
+            inProgress: t("common.downloading"),
+            finalizing: t("common.extracting"),
+          }}
+          onClick={handleDownload}
+          inProgress={inProgress}
+          setInProgress={setInProgress}
+        />
+      ) : (
+        database.manualDownloadLink && (
+          <Button component="a" href={database.manualDownloadLink} target="_blank" rel="noreferrer" fullWidth>
+            {t("common.download")}
+          </Button>
+        )
+      )}
     </Paper>
   );
 }
@@ -488,7 +496,7 @@ const _PuzzleDbCard = function PuzzleDbCard({ setPuzzleDbs, puzzleDb, databaseId
   const [willImport, setWillImport] = useState<boolean>(false); // Flag to indicate we will import after download
 
   // Check if it's a CSV file (needs import) or a database file (direct download)
-  const isCsvFile = puzzleDb.downloadLink?.endsWith(".csv") || puzzleDb.downloadLink?.endsWith(".csv.zst");
+  const isCsvFile = !!(puzzleDb.downloadLink?.endsWith(".csv") || puzzleDb.downloadLink?.endsWith(".csv.zst"));
 
   // Listen to import progress events for CSV files
   useEffect(() => {
@@ -634,27 +642,35 @@ const _PuzzleDbCard = function PuzzleDbCard({ setPuzzleDbs, puzzleDb, databaseId
         </Stack>
       </Group>
 
-      <ProgressButton
-        id={`puzzle_db_${databaseId}`}
-        progressEvent={events.downloadProgress}
-        initInstalled={initInstalled}
-        labels={{
-          completed: t("common.installed"),
-          action: t("common.install"),
-          inProgress: isCsvFile && isImporting ? t("common.importing") : t("common.downloading"),
-          finalizing: isCsvFile && isImporting ? t("common.importing") : t("common.extracting"),
-        }}
-        onClick={handleDownload}
-        inProgress={combinedInProgress}
-        setInProgress={(value) => {
-          // For CSV files, prevent ProgressButton from setting inProgress to false
-          // when download finishes, because we still need to import
-          // For non-CSV files, allow normal behavior
-          if (!isCsvFile || (!isImporting && !willImport)) {
-            setInProgress(value);
-          }
-        }}
-      />
+      {puzzleDb.downloadLink ? (
+        <ProgressButton
+          id={`puzzle_db_${databaseId}`}
+          progressEvent={events.downloadProgress}
+          initInstalled={initInstalled}
+          labels={{
+            completed: t("common.installed"),
+            action: t("common.install"),
+            inProgress: isCsvFile && isImporting ? t("common.importing") : t("common.downloading"),
+            finalizing: isCsvFile && isImporting ? t("common.importing") : t("common.extracting"),
+          }}
+          onClick={handleDownload}
+          inProgress={combinedInProgress}
+          setInProgress={(value) => {
+            // For CSV files, prevent ProgressButton from setting inProgress to false
+            // when download finishes, because we still need to import
+            // For non-CSV files, allow normal behavior
+            if (!isCsvFile || (!isImporting && !willImport)) {
+              setInProgress(value);
+            }
+          }}
+        />
+      ) : (
+        puzzleDb.manualDownloadLink && (
+          <Button component="a" href={puzzleDb.manualDownloadLink} target="_blank" rel="noreferrer" fullWidth>
+            {t("common.download")}
+          </Button>
+        )
+      )}
     </Paper>
   );
 };

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -30,7 +30,8 @@ export type DownloadableDatabase = {
   game_count: number;
   player_count: number;
   storage_size: bigint;
-  downloadLink: string;
+  downloadLink?: string;
+  manualDownloadLink?: string;
   description?: string;
 };
 // TODO: These two types should follow the same format (camelCase vs snake_case)
@@ -39,10 +40,51 @@ export type DownloadablePuzzleDatabase = {
   description: string;
   puzzleCount: number;
   storageSize: bigint;
-  downloadLink: string;
+  downloadLink?: string;
+  manualDownloadLink?: string;
 };
 
 const DATABASES: DownloadableDatabase[] = [
+  {
+    title: "Lumbra's Gigabase",
+    game_count: 9570564,
+    player_count: 526520,
+    storage_size: BigInt(2789040128),
+    manualDownloadLink: "https://lumbrasgigabase.com/en/",
+    description: "Manual download source. Download the database externally, then import a PGN locally.",
+  },
+  {
+    title: "Caissabase 2024",
+    game_count: 5404926,
+    player_count: 321095,
+    storage_size: BigInt(1318744064),
+    manualDownloadLink: "https://web.archive.org/web/20241007103203/http://caissabase.co.uk/",
+    description: "Manual download source. Download the database externally, then import a PGN locally.",
+  },
+  {
+    title: "Ajedrez Data - Correspondence",
+    game_count: 1524027,
+    player_count: 40547,
+    storage_size: BigInt(328458240),
+    manualDownloadLink: "https://ajedrezdata.com/databases/",
+    description: "Manual download source. Download the correspondence database externally, then import a PGN locally.",
+  },
+  {
+    title: "Ajedrez Data - OTB",
+    game_count: 4279012,
+    player_count: 144015,
+    storage_size: BigInt(993509376),
+    manualDownloadLink: "https://ajedrezdata.com/databases/",
+    description: "Manual download source. Download the OTB database externally, then import a PGN locally.",
+  },
+  {
+    title: "MillionBase",
+    game_count: 3451068,
+    player_count: 284403,
+    storage_size: BigInt(779833344),
+    manualDownloadLink: "https://www.rebel.nl/milbase.htm",
+    description: "Manual download source. Download the database externally, then import a PGN locally.",
+  },
   {
     title: "Position Cache",
     game_count: 0,
@@ -56,11 +98,18 @@ const DATABASES: DownloadableDatabase[] = [
 
 const PUZZLE_DATABASES: DownloadablePuzzleDatabase[] = [
   {
+    title: "Lichess Puzzles",
+    description: "Manual download source. Download from Lichess, then import the puzzle file locally.",
+    puzzleCount: 3080529,
+    storageSize: BigInt(339046400),
+    manualDownloadLink: "https://database.lichess.org/#puzzles",
+  },
+  {
     title: "Lichess Puzzles 2025",
-    description: "Latest puzzles from Lichess.org organized by themes in database format",
+    description: "Manual download source. Download this large database externally, then import it locally.",
     puzzleCount: 5600086,
     storageSize: BigInt(3542036480), // 3,459,020 KB = 3,542,036,480 bytes
-    downloadLink: "https://pub-ea015655e3e044baaea19e7e0bf574f9.r2.dev/Lichess%20Puzzles%202025.db3",
+    manualDownloadLink: "https://pub-ea015655e3e044baaea19e7e0bf574f9.r2.dev/Lichess%20Puzzles%202025.db3",
   },
 ];
 
@@ -200,7 +249,10 @@ export function useDefaultDatabases(opened: boolean) {
   const { data, error, isLoading } = useQuery({
     queryKey: ["default-dbs"],
     queryFn: async () => {
-      return DATABASES as SuccessDatabaseInfo[];
+      return DATABASES as (SuccessDatabaseInfo & {
+        downloadLink?: string;
+        manualDownloadLink?: string;
+      })[];
     },
     enabled: opened,
     staleTime: Infinity,
@@ -212,9 +264,12 @@ export function useDefaultDatabases(opened: boolean) {
   };
 }
 
-export async function getDefaultPuzzleDatabases(): Promise<(PuzzleDatabaseInfo & { downloadLink: string })[]> {
+export async function getDefaultPuzzleDatabases(): Promise<
+  (PuzzleDatabaseInfo & { downloadLink?: string; manualDownloadLink?: string })[]
+> {
   return PUZZLE_DATABASES as (PuzzleDatabaseInfo & {
-    downloadLink: string;
+    downloadLink?: string;
+    manualDownloadLink?: string;
   })[];
 }
 


### PR DESCRIPTION
# Pull Request

## Description
Adds manual external download links for downloadable chess content whose hosted in-app downloads are unavailable or unreliable.

This keeps `Position Cache` as an in-app install, but changes the large `Lichess Puzzles 2025` database to a manual download link because the in-app download can fail near completion with `error decoding response body`.

It also restores the previously removed database and puzzle entries as manual-download options, so users can download the content externally and import it locally instead of losing access to those sources.

Related issue: #6

## How This Was Tested
- [x] Development testing completed
- [x] Built successfully

**Tested on:**  
Windows, local checkout.

Ran:

```sh
corepack pnpm exec tsc --noEmit
corepack pnpm biome check src/utils/db.ts src/features/boards/components/puzzles/AddPuzzle.tsx src/features/databases/components/modals/AddDatabase.tsx
```

Result:
- TypeScript completed successfully.
- Targeted Biome check completed successfully for the changed files.
- Biome reported existing unrelated warnings in those files, but no formatter/type error was introduced by this change.

## Screenshots / Additional Context
Verified the manual source pages respond with `200 OK` using `curl.exe -I -L`.

The full `corepack pnpm lint` command still exits with existing unrelated Biome diagnostics across the repository, including generated bindings and existing components.

## Checklist
- [x] Followed contributing guidelines
- [x] Reviewed code for style and correctness